### PR TITLE
Update lmdb_ext.h - remove duplicate Transaction typedef

### DIFF
--- a/ext/lmdb_ext/lmdb_ext.h
+++ b/ext/lmdb_ext/lmdb_ext.h
@@ -22,8 +22,6 @@
         Data_Get_Struct(var, Cursor, var_cur);  \
         cursor_check(var_cur)
 
-typedef struct Transaction Transaction;
-
 typedef struct Transaction {
         VALUE    env;
         VALUE    parent;


### PR DESCRIPTION
Recent gcc complains that redefinition of typedef Transaction is not allowed.
