### PR TITLE
Environment should have flags and call_with_transaction should use it

### DIFF
--- a/ext/lmdb_ext/lmdb_ext.c
+++ b/ext/lmdb_ext/lmdb_ext.c
@@ -179,7 +179,10 @@ static VALUE call_with_transaction_helper(VALUE arg) {
 #endif
 
 static VALUE call_with_transaction(VALUE venv, VALUE self, const char* name, int argc, const VALUE* argv, int flags) {
+        ENVIRONMENT(venv, environment);
         HelperArgs arg = { self, name, argc, argv };
+        if(environment->flags & MDB_RDONLY)
+          flags |= MDB_RDONLY;
         return with_transaction(venv, call_with_transaction_helper, (VALUE)&arg, flags);
 }
 
@@ -490,6 +493,7 @@ static VALUE environment_new(int argc, VALUE *argv, VALUE klass) {
         environment->env = env;
         environment->thread_txn_hash = rb_hash_new();
         environment->txn_thread_hash = rb_hash_new();
+        environment->flags = options.flags;
 
         if (options.maxreaders > 0)
                 check(mdb_env_set_maxreaders(env, options.maxreaders));

--- a/ext/lmdb_ext/lmdb_ext.h
+++ b/ext/lmdb_ext/lmdb_ext.h
@@ -59,6 +59,7 @@ typedef struct {
         MDB_env* env;
         VALUE    thread_txn_hash;
         VALUE    txn_thread_hash;
+        int      flags;
 } Environment;
 
 typedef struct {


### PR DESCRIPTION
Hi,
The following code falls in an infinite loop.

```ruby
require "lmdb"

env = LMDB.new("dir_lmdb")
db = env.database("abc", create: true)
env.close

env = LMDB.new("dir_lmdb", rdonly: true)
db = env.database("abc")
```

Transaction seems to have to be created with MDB_RDONLY flag under read-only environment. 

I have not read the documents and the codes of LMDB. So I am not sure this is a proper solution.

I hope this helping your development.

Regards,