### PR TITLE
Fix keyword arguments warning on Ruby 2.7

### DIFF
--- a/ext/lmdb_ext/lmdb_ext.c
+++ b/ext/lmdb_ext/lmdb_ext.c
@@ -755,7 +755,7 @@ static VALUE environment_database(int argc, VALUE *argv, VALUE self) {
                 return call_with_transaction(self, self, "database", argc, argv, 0);
 
         VALUE name, option_hash;
-        rb_scan_args(argc, argv, "01:", &name, &option_hash);
+        rb_scan_args_kw(RB_SCAN_ARGS_KEYWORDS, argc, argv, "01:", &name, &option_hash);
 
         int flags = 0;
         if (!NIL_P(option_hash))

--- a/lmdb.gemspec
+++ b/lmdb.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.required_ruby_version = ">= 1.9.3"
-  s.add_development_dependency 'rake', "~> 10.0"
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rake-compiler', '<=0.8.2'
   s.add_development_dependency 'rspec', "~> 3.0"
 end


### PR DESCRIPTION
This gets rid of the `warning: Using the last argument as keyword parameters is deprecated` when calling `Environment#database` with flags.

cc @doriantaylor @minad 