### PR TITLE
Fix ruby 3.1.0-dev compatibility

### DIFF
--- a/ext/lmdb_ext/extconf.rb
+++ b/ext/lmdb_ext/extconf.rb
@@ -1,6 +1,6 @@
 require 'mkmf'
 
-$CFLAGS = '-std=c99 -Wall -g'
+$CFLAGS << ' -std=c99 -Wall -g '
 
 # Embed lmdb if we cannot find it
 if enable_config("bundled-lmdb", false) || !(find_header('lmdb.h') && have_library('lmdb', 'mdb_env_create'))


### PR DESCRIPTION
Replacing `$FLAGS` entirely cause issues with Ruby 3.1.0-dev and clang because it gets rid of `-fdeclspec`.